### PR TITLE
[feat] Ticket 발급 기능 생성

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/event/Event.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/Event.java
@@ -1,5 +1,6 @@
 package com.festimap.tiketing.domain.event;
 
+import com.festimap.tiketing.domain.ticket.Ticket;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,24 +18,24 @@ public class Event {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "festival_id")
+    @Column(name = "festival_id", nullable = false)
     private String festivalId;
 
-    @Column(name = "name")
+    @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "total")
+    @Column(name = "total", nullable = false)
     private int total;
 
-    @Column(name = "remaining")
+    @Column(name = "remaining", nullable = false)
     private int remaining;
 
-    @Column(name = "open_at")
+    @Column(name = "open_at", nullable = false)
     private LocalDateTime openAt;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "event")
-    private List<Event> events = new ArrayList<>();
+    private List<Ticket> tickets = new ArrayList<>();
 }

--- a/src/main/java/com/festimap/tiketing/domain/event/Event.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/Event.java
@@ -1,0 +1,40 @@
+package com.festimap.tiketing.domain.event;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "event")
+public class Event {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "festival_id")
+    private String festivalId;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "total")
+    private int total;
+
+    @Column(name = "remaining")
+    private int remaining;
+
+    @Column(name = "open_at")
+    private LocalDateTime openAt;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "event")
+    private List<Event> events = new ArrayList<>();
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -9,24 +9,33 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "ticket")
+@Table(name = "ticket",
+        uniqueConstraints = @UniqueConstraint(
+                name = "unique_ticket_reservation_phone",
+                columnNames = {"reservation_number", "phone_number"}
+        )
+)
 public class Ticket {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "count")
+    @Column(name = "count", nullable = false)
     private int count;
 
-    @Column(name = "reservation_num", length = 10)
-    private String reservationNum;
+    @Column(name = "reservation_number", length = 10, nullable = false)
+    private String reservationNumber;
 
-    @Column(name = "phone_num", length = 11)
-    private String phoneNum;
+    @Column(name = "phone_number", length = 11, nullable = false)
+    private String phoneNumber;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
@@ -35,8 +44,8 @@ public class Ticket {
     @Builder
     private Ticket(int count, String phoneNo) {
         this.count = count;
-        this.reservationNum = ReservationNumGenerator.generate();
-        this.phoneNum = phoneNo;
+        this.reservationNumber = ReservationNumGenerator.generate();
+        this.phoneNumber = phoneNo;
     }
 
     public static Ticket from(TicketRequest request){

--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -2,13 +2,11 @@ package com.festimap.tiketing.domain.ticket;
 
 import com.festimap.tiketing.domain.event.Event;
 import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
-import com.festimap.tiketing.global.util.ReservationNoGenerator;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import com.festimap.tiketing.global.util.ReservationNumGenerator;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.context.annotation.Bean;
 
 import javax.persistence.*;
 
@@ -24,11 +22,11 @@ public class Ticket {
     @Column(name = "count")
     private int count;
 
-    @Column(name = "reservation_no")
-    private String reservationNo;
+    @Column(name = "reservation_num", length = 10)
+    private String reservationNum;
 
-    @Column(name = "phone_no")
-    private String phoneNo;
+    @Column(name = "phone_num", length = 11)
+    private String phoneNum;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
@@ -37,8 +35,8 @@ public class Ticket {
     @Builder
     private Ticket(int count, String phoneNo) {
         this.count = count;
-        this.reservationNo = ReservationNoGenerator.generate();
-        this.phoneNo = phoneNo;
+        this.reservationNum = ReservationNumGenerator.generate();
+        this.phoneNum = phoneNo;
     }
 
     public static Ticket from(TicketRequest request){

--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -1,0 +1,50 @@
+package com.festimap.tiketing.domain.ticket;
+
+import com.festimap.tiketing.domain.event.Event;
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.global.util.ReservationNoGenerator;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ticket")
+public class Ticket {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "count")
+    private int count;
+
+    @Column(name = "reservation_no")
+    private String reservationNo;
+
+    @Column(name = "phone_no")
+    private String phoneNo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @Builder
+    private Ticket(int count, String phoneNo) {
+        this.count = count;
+        this.reservationNo = ReservationNoGenerator.generate();
+        this.phoneNo = phoneNo;
+    }
+
+    public static Ticket from(TicketRequest request){
+        return Ticket.builder()
+                .count(request.getTicketCount())
+                .phoneNo(request.getPhoneNo())
+                .build();
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -51,7 +51,7 @@ public class Ticket {
     public static Ticket from(TicketRequest request){
         return Ticket.builder()
                 .count(request.getTicketCount())
-                .phoneNo(request.getPhoneNo())
+                .phoneNo(request.getPhoneNumber())
                 .build();
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
@@ -1,0 +1,30 @@
+package com.festimap.tiketing.domain.ticket.controller;
+
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.global.error.ErrorCode;
+import com.festimap.tiketing.global.error.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TicketController {
+
+    private final BlockingQueue<TicketRequest> ticketQueue;
+    private AtomicLong requestOrder = new AtomicLong(0);
+
+    @PostMapping("/tickets/apply")
+    public String apply(@RequestBody TicketRequest request) {
+        if (requestOrder.incrementAndGet() > 2400 || !ticketQueue.offer(request)) {
+            throw new BaseException(ErrorCode.TICKET_RESERVATION_CLOSED);
+        }
+        return "신청됐습니다.";
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
@@ -1,0 +1,13 @@
+package com.festimap.tiketing.domain.ticket.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.Pattern;
+
+@Getter
+public class TicketRequest {
+
+    @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phoneNo;
+    private int ticketCount;
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
@@ -8,6 +8,6 @@ import javax.validation.constraints.Pattern;
 public class TicketRequest {
 
     @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다.")
-    private String phoneNo;
+    private String phoneNumber;
     private int ticketCount;
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.Pattern;
 @Getter
 public class TicketRequest {
 
+    private Long eventId;
     @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
     private int ticketCount;

--- a/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
@@ -1,0 +1,8 @@
+package com.festimap.tiketing.domain.ticket.repository;
+
+import com.festimap.tiketing.domain.ticket.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    boolean existsByPhoneNo(String phoneNo);
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
@@ -4,5 +4,5 @@ import com.festimap.tiketing.domain.ticket.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
-    boolean existsByPhoneNo(String phoneNo);
+    boolean existsByPhoneNumber(String phoneNo);
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
@@ -4,5 +4,5 @@ import com.festimap.tiketing.domain.ticket.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
-    boolean existsByPhoneNumber(String phoneNo);
+    boolean existsByEventIdAndPhoneNumber(Long eventId, String phoneNumber);
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
@@ -17,13 +17,13 @@ public class TicketService {
 
     @Transactional
     public void reserve(TicketRequest request) {
-        isExistTicketBy(request.getPhoneNumber());
+        isExistTicketBy(request.getEventId(), request.getPhoneNumber());
         Ticket ticket = Ticket.from(request);
         ticketRepository.save(ticket);
     }
 
-    private void isExistTicketBy(String phoneNo) {
-        if(ticketRepository.existsByPhoneNumber(phoneNo)){
+    private void isExistTicketBy(Long eventId, String phoneNo) {
+        if(ticketRepository.existsByEventIdAndPhoneNumber(eventId, phoneNo)){
             throw new BaseException(ErrorCode.TICKET_EXIST_BY_PHONENUM);
         }
     }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
@@ -17,13 +17,13 @@ public class TicketService {
 
     @Transactional
     public void reserve(TicketRequest request) {
-        isExistTicketBy(request.getPhoneNo());
+        isExistTicketBy(request.getPhoneNumber());
         Ticket ticket = Ticket.from(request);
         ticketRepository.save(ticket);
     }
 
     private void isExistTicketBy(String phoneNo) {
-        if(ticketRepository.existsByPhoneNo(phoneNo)){
+        if(ticketRepository.existsByPhoneNumber(phoneNo)){
             throw new BaseException(ErrorCode.TICKET_EXIST_BY_PHONENUM);
         }
     }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
@@ -1,0 +1,30 @@
+package com.festimap.tiketing.domain.ticket.service;
+
+import com.festimap.tiketing.domain.ticket.Ticket;
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.domain.ticket.repository.TicketRepository;
+import com.festimap.tiketing.global.error.ErrorCode;
+import com.festimap.tiketing.global.error.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+
+    @Transactional
+    public void reserve(TicketRequest request) {
+        isExistTicketBy(request.getPhoneNo());
+        Ticket ticket = Ticket.from(request);
+        ticketRepository.save(ticket);
+    }
+
+    private void isExistTicketBy(String phoneNo) {
+        if(ticketRepository.existsByPhoneNo(phoneNo)){
+            throw new BaseException(ErrorCode.TICKET_EXIST_BY_PHONENUM);
+        }
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/worker/TicketRequestQueueWorker.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/worker/TicketRequestQueueWorker.java
@@ -1,0 +1,34 @@
+package com.festimap.tiketing.domain.ticket.worker;
+
+
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.domain.ticket.service.TicketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+
+@Component
+@RequiredArgsConstructor
+public class TicketRequestQueueWorker {
+
+    private final BlockingQueue<TicketRequest> ticketQueue;
+    private final TicketService ticketService;
+
+    @PostConstruct
+    public void start() {
+        Executors.newSingleThreadExecutor().submit(this::processQueue);
+    }
+
+    private void processQueue() {
+        while (true) {
+            try {
+                ticketService.reserve(ticketQueue.take());
+            } catch (Exception e) {
+                // TODO: log
+            }
+        }
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/worker/TicketRequestQueueWorker.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/worker/TicketRequestQueueWorker.java
@@ -18,6 +18,7 @@ public class TicketRequestQueueWorker {
     private final TicketService ticketService;
 
     @PostConstruct
+    //  @Scheduled(cron = "0 0 0 * * *")
     public void start() {
         Executors.newSingleThreadExecutor().submit(this::processQueue);
     }

--- a/src/main/java/com/festimap/tiketing/global/config/queue/RequestQueueConfig.java
+++ b/src/main/java/com/festimap/tiketing/global/config/queue/RequestQueueConfig.java
@@ -1,0 +1,19 @@
+package com.festimap.tiketing.global.config.queue;
+
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+@Configuration
+public class RequestQueueConfig {
+
+    private static final int TICKET_REQUEST_QUEUE_SIZE = 2400;
+
+    @Bean
+    public BlockingQueue<TicketRequest> ticketQueue() {
+        return new ArrayBlockingQueue<>(TICKET_REQUEST_QUEUE_SIZE);
+    }
+}

--- a/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
+++ b/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     // Infra
     SMS_SEND_FAILED("I001", "SMS Send Failed",500),
 
+    // Ticketing
+    TICKET_RESERVATION_CLOSED("T001", "Ticket Reservation Closed",429),
+    TICKET_EXIST_BY_PHONENUM("T002", "Ticket Exist By Phone Number",400),
     ;
 
     private final String code;

--- a/src/main/java/com/festimap/tiketing/global/util/ReservationNoGenerator.java
+++ b/src/main/java/com/festimap/tiketing/global/util/ReservationNoGenerator.java
@@ -1,0 +1,11 @@
+package com.festimap.tiketing.global.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReservationNoGenerator {
+
+    public static String generate(){
+        return "";
+    }
+}

--- a/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
+++ b/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
@@ -3,7 +3,7 @@ package com.festimap.tiketing.global.util;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ReservationNoGenerator {
+public class ReservationNumGenerator {
 
     public static String generate(){
         return "";

--- a/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
+++ b/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ReservationNumGenerator {
 
+    // TODO : 예약번호 생성 전략 선택 후 로직 완성
     public static String generate(){
         return "";
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #3 

## 📝작업 내용

- Ticket, Event 엔티티 정의
- 티켓 발급 요청 시 2400개의 요청만 BlockingQueue에 넣은 후 2400번째를 넘어가는 요청은 reject하도록 설계
- BlockingQueue에 요청이 들어오면 요청을 처리해 티켓을 발급하는 Worker 클래스 정의

## TODO
- 티켓 발급 전 인증 여부 필드인 isVerified가 true이면서 verifiedExpiredAt이 지나지 않음을 검증한 후 발급
- 티켓 예약번호 생성 전략 선택 
- 테스트 코드 작성
