### PR TITLE
[feat] 티켓 예매 번호 생성 전략 추가

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/event/Event.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/Event.java
@@ -46,6 +46,9 @@ public class Event {
     @Column(name = "is_finished", nullable = false)
     private boolean isFinished = false;
 
+    @Column(name = "prefix", nullable = false)
+    private String prefix;
+
     @Column(name = "created_at", nullable = false)
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -48,7 +48,7 @@ public class Ticket {
     @Builder
     private Ticket(int count, String phoneNo, Event event) {
         this.count = count;
-        this.reservationNumber = ReservationNumGenerator.generate(event.getRemainingTickets());
+        this.reservationNumber = ReservationNumGenerator.generate(event.getPrefix(), event.getRemainingTickets());
         this.phoneNumber = phoneNo;
         this.event = event;
     }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -48,16 +48,9 @@ public class Ticket {
     @Builder
     private Ticket(int count, String phoneNo, Event event) {
         this.count = count;
-        this.reservationNumber = ReservationNumGenerator.generate();
+        this.reservationNumber = ReservationNumGenerator.generate(event.getRemainingTickets());
         this.phoneNumber = phoneNo;
         this.event = event;
-    }
-
-    public static Ticket from(TicketRequest request){
-        return Ticket.builder()
-                .count(request.getTicketCount())
-                .phoneNo(request.getPhoneNumber())
-                .build();
     }
 
     public static Ticket of(TicketRequest ticketRequest, Event event){

--- a/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
+++ b/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
@@ -2,11 +2,20 @@ package com.festimap.tiketing.global.util;
 
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
 @Component
 public class ReservationNumGenerator {
 
-    // TODO : 예약번호 생성 전략 선택 후 로직 완성
-    public static String generate(){
-        return "";
+
+    private static final String PREFIX = "MW";
+
+    public static String generate(int remainingTicket) {
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyMMdd"));
+        String random = UUID.randomUUID().toString().replace("-", "").substring(0, 5).toUpperCase();
+        String formatted = String.format("%04d", remainingTicket);
+        return PREFIX + date + random + formatted;
     }
 }

--- a/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
+++ b/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
@@ -9,13 +9,10 @@ import java.util.UUID;
 @Component
 public class ReservationNumGenerator {
 
-
-    private static final String PREFIX = "MW";
-
-    public static String generate(int remainingTicket) {
+    public static String generate(String eventPrefix, int remainingTicket) {
         String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyMMdd"));
         String random = UUID.randomUUID().toString().replace("-", "").substring(0, 5).toUpperCase();
         String formatted = String.format("%04d", remainingTicket);
-        return PREFIX + date + random + formatted;
+        return eventPrefix + date + random + formatted;
     }
 }

--- a/src/test/java/com/festimap/tiketing/domain/ticket/utils/ReservationNumGeneratorTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/utils/ReservationNumGeneratorTest.java
@@ -1,0 +1,27 @@
+package com.festimap.tiketing.domain.ticket.utils;
+
+
+import com.festimap.tiketing.global.util.ReservationNumGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+public class ReservationNumGeneratorTest {
+
+    @Test
+    void 예매번호_생성() {
+        int remaining = 42;
+        String reservationNum = ReservationNumGenerator.generate(remaining);
+
+        System.out.println(reservationNum);
+        assertEquals(17, reservationNum.length());
+        assertTrue(reservationNum.matches("^MW\\d{6}[A-Z0-9]{5}\\d{4}$"));
+    }
+}

--- a/src/test/java/com/festimap/tiketing/domain/ticket/utils/ReservationNumGeneratorTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/utils/ReservationNumGeneratorTest.java
@@ -18,7 +18,8 @@ public class ReservationNumGeneratorTest {
     @Test
     void 예매번호_생성() {
         int remaining = 42;
-        String reservationNum = ReservationNumGenerator.generate(remaining);
+        String prefix = "MW";
+        String reservationNum = ReservationNumGenerator.generate(prefix, remaining);
 
         System.out.println(reservationNum);
         assertEquals(17, reservationNum.length());


### PR DESCRIPTION
## #️⃣연관된 이슈

- #12 

## 📝작업 내용

티켓 예매번호 발급 로직을 추가했습니다.
`
MW250415983850042
`
- (이벤트 prefix 2자리) + (발급날짜 6자리) + (랜덤 UUID 5자리) + (잔여 티켓수 4자리)
- 현재 생성 전략은 특정 이벤트에 맞춰져있어 추후에 수정해야 합니다.