### PR TITLE
[feat] Verification 관련 검증 추가

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/verification/Verification.java
+++ b/src/main/java/com/festimap/tiketing/domain/verification/Verification.java
@@ -11,8 +11,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+
 
 @Entity
 @Table(name = "verification",

--- a/src/main/java/com/festimap/tiketing/domain/verification/controller/VerificationController.java
+++ b/src/main/java/com/festimap/tiketing/domain/verification/controller/VerificationController.java
@@ -4,6 +4,7 @@ import com.festimap.tiketing.domain.verification.dto.VerificationCheckReqDto;
 import com.festimap.tiketing.domain.verification.dto.VerificationReqDto;
 import com.festimap.tiketing.domain.verification.service.VerificationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,12 +15,12 @@ public class VerificationController {
     private final VerificationService verificationService;
 
     @PostMapping("/send/code")
-    public void sendVerificationCode(@RequestBody VerificationReqDto verificationReqDto) {
+    public void sendVerificationCode(@RequestBody @Validated VerificationReqDto verificationReqDto) {
         verificationService.sendVerificationCode(verificationReqDto);
     }
 
     @PostMapping("/check/code")
-    public void checkVerificationCode(@RequestBody VerificationCheckReqDto verificationCheckReqDto) {
+    public void checkVerificationCode(@RequestBody @Validated VerificationCheckReqDto verificationCheckReqDto) {
         verificationService.checkVerificationCode(verificationCheckReqDto);
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/verification/dto/VerificationCheckReqDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/verification/dto/VerificationCheckReqDto.java
@@ -3,10 +3,16 @@ package com.festimap.tiketing.domain.verification.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Pattern;
+
 @Getter
 @NoArgsConstructor
 public class VerificationCheckReqDto {
+
+    @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
+
+    @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
     private String code;
 
     public VerificationCheckReqDto(String phoneNumber, String code) {

--- a/src/main/java/com/festimap/tiketing/domain/verification/dto/VerificationReqDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/verification/dto/VerificationReqDto.java
@@ -3,12 +3,18 @@ package com.festimap.tiketing.domain.verification.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+
 @Getter
 @NoArgsConstructor
 public class VerificationReqDto {
-    private String phoneNumber;
 
-    public VerificationReqDto(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
+    @NotNull(message = "eventId는 필수입니다.")
+    @Positive(message = "eventId는 0보다 커야 합니다.")
+    private Long eventId;
+
+    @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phoneNumber;
 }

--- a/src/test/java/com/festimap/tiketing/domain/ticket/service/TicketConcurrencyTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/service/TicketConcurrencyTest.java
@@ -4,7 +4,6 @@ package com.festimap.tiketing.domain.ticket.service;
 import com.festimap.tiketing.domain.event.Event;
 import com.festimap.tiketing.domain.event.dto.EventCreateReqDto;
 import com.festimap.tiketing.domain.event.repository.EventRepository;
-import com.festimap.tiketing.domain.event.service.EventService;
 import com.festimap.tiketing.domain.ticket.Ticket;
 import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
 import com.festimap.tiketing.domain.ticket.repository.TicketRepository;
@@ -34,9 +33,6 @@ public class TicketConcurrencyTest {
 
     @Autowired
     private TicketRepository ticketRepository;
-
-    @Autowired
-    private EventService eventService;
 
     private Event event;
     @Autowired

--- a/src/test/java/com/festimap/tiketing/domain/verification/VerificationTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/verification/VerificationTest.java
@@ -19,14 +19,18 @@ public class VerificationTest {
 
     @BeforeEach
     void setUp(){
-        VerificationReqDto verificationReqDto = new VerificationReqDto("01012345678");
+        VerificationReqDto verificationReqDto = new VerificationReqDto();
+        setField(verificationReqDto, "eventId", 1L);
+        setField(verificationReqDto, "phoneNumber", "01012345678");
         verification = Verification.from(verificationReqDto);
     }
 
     @Test
     void verification_생성_테스트(){
         //given
-        VerificationReqDto verificationReqDto = new VerificationReqDto("01012345678");
+        VerificationReqDto verificationReqDto = new VerificationReqDto();
+        setField(verificationReqDto, "eventId", 1L);
+        setField(verificationReqDto, "phoneNumber", "01012345678");
 
         //when
         Verification target = Verification.from(verificationReqDto);

--- a/src/test/java/com/festimap/tiketing/domain/verification/controller/VerificationControllerTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/verification/controller/VerificationControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,7 +45,9 @@ public class VerificationControllerTest {
     @Test
     void 인증코드_전송_요청_테스트()throws Exception{
         //given
-        VerificationReqDto verificationReqDto = new VerificationReqDto("01012345678");
+        VerificationReqDto verificationReqDto = new VerificationReqDto();
+        setField(verificationReqDto, "eventId", 1L);
+        setField(verificationReqDto, "phoneNumber", "01012345678");
         doNothing().when(verificationService).sendVerificationCode(any());
 
         //when & then

--- a/src/test/java/com/festimap/tiketing/domain/verification/repository/VerificationRepositoryTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/verification/repository/VerificationRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(SpringExtension.class)
 @Disabled
@@ -32,7 +33,9 @@ public class VerificationRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        VerificationReqDto verificationReqDto = new VerificationReqDto("01012345678");
+        VerificationReqDto verificationReqDto = new VerificationReqDto();
+        setField(verificationReqDto, "eventId", 1L);
+        setField(verificationReqDto, "phoneNumber", "01012345678");
         verification = verificationRepository.save(Verification.from(verificationReqDto));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #11 

## 📝작업 내용

1. VerificationController에 Validation을 추가하였습니다.
2. 인증코드 발송 전에 eventId의 isFinished를 조회해서 이미 종료된 event라면 더 이상 문자 인증을 하지 못하도록 검증 로직 추가
3. eventId가 존재하지 않을 경우 검증 로직 추가
4. VerificationService의 event 관련 검증 로직 테스트 코드 추가


