### PR TITLE
[feat] Ticket Validation 추가

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
@@ -4,6 +4,7 @@ import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
 import com.festimap.tiketing.global.error.ErrorCode;
 import com.festimap.tiketing.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,10 +22,9 @@ public class TicketController {
     private AtomicLong requestOrder = new AtomicLong(0);
 
     @PostMapping("/tickets/apply")
-    public String apply(@RequestBody TicketRequest request) {
+    public void apply(@Validated @RequestBody TicketRequest request) {
         if (requestOrder.incrementAndGet() > 2400 || !ticketQueue.offer(request)) {
             throw new BaseException(ErrorCode.TICKET_RESERVATION_CLOSED);
         }
-        return "신청됐습니다.";
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketRequest.java
@@ -1,14 +1,18 @@
 package com.festimap.tiketing.domain.ticket.dto;
 
 import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 @Getter
 public class TicketRequest {
 
+    @NotNull(message = "이벤트Id가 누락됐습니다")
     private Long eventId;
     @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
+    @Range(min = 1, max = 2, message = "1~2장만 신청 가능합니다.")
     private int ticketCount;
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
@@ -2,7 +2,12 @@ package com.festimap.tiketing.domain.ticket.repository;
 
 import com.festimap.tiketing.domain.ticket.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
-    boolean existsByEventIdAndPhoneNumber(Long eventId, String phoneNumber);
+
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END " +
+            "FROM Ticket t WHERE t.event.id = :eventId AND t.phoneNumber = :phoneNumber")
+    boolean existsByEventIdAndPhoneNumber(@Param("eventId") Long eventId, @Param("phoneNumber") String phoneNumber);
 }

--- a/src/main/java/com/festimap/tiketing/global/constants/SecurityConstants.java
+++ b/src/main/java/com/festimap/tiketing/global/constants/SecurityConstants.java
@@ -12,5 +12,6 @@ public class SecurityConstants {
     public static final String[] PUBLIC_POST_URLS = {
             "/api/verification/send/code",
             "/api/verification/check/code",
+            "/api/tickets/apply"
     };
 }

--- a/src/main/java/com/festimap/tiketing/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/festimap/tiketing/global/error/GlobalExceptionHandler.java
@@ -3,9 +3,11 @@ package com.festimap.tiketing.global.error;
 import com.festimap.tiketing.global.error.exception.BaseException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAsyncThreadPoolTaskLimitException(RejectedExecutionException e) {
         final ErrorResponse response = ErrorResponse.of(ErrorCode.THREAD_POOL_REJECTED);
         return ResponseEntity.status(ErrorCode.THREAD_POOL_REJECTED.getStatus()).body(response);
+    }
+
+    // MethodArgumentNotValidException 핸들링
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> onThrowException(MethodArgumentNotValidException e){
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+        System.out.println(errorMessage);
+        ErrorResponse errorResponse = ErrorResponse.of(errorMessage, ErrorCode.INVALID_INPUT_VALUE);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 }

--- a/src/test/java/com/festimap/tiketing/domain/ticket/controller/TicketControllerTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/controller/TicketControllerTest.java
@@ -1,0 +1,59 @@
+package com.festimap.tiketing.domain.ticket.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.domain.verification.controller.VerificationController;
+import com.festimap.tiketing.global.config.security.SecurityConfig;
+import com.festimap.tiketing.global.testsupport.ControllerTestSecurityBeans;
+import com.festimap.tiketing.global.util.JwtProvider;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.concurrent.BlockingQueue;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TicketController.class)
+@AutoConfigureMockMvc
+@SuppressWarnings("NonAsciiCharacters")
+@ActiveProfiles("test")
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
+public class TicketControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private BlockingQueue<TicketRequest> ticketQueue;
+
+    @Test
+    void 티켓발급요청_검증() throws Exception {
+        TicketRequest request = new TicketRequest();
+        setField(request, "eventId", 1L);
+        setField(request, "phoneNumber", "01012341234");
+        setField(request, "ticketCount", 3);
+
+        mockMvc.perform(post("/api/tickets/apply")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #3 

## 📝작업 내용

- TicketRequest의 Validation 추가
- TicketRepository 티켓 존재여부 쿼리 정의
- TicketController RequestBody의 Validation 검증
