### PR TITLE
[feat] 티켓 중복 확인 쿼리 수정

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -31,7 +31,7 @@ public class Ticket {
     @Column(name = "count", nullable = false)
     private int count;
 
-    @Column(name = "reservation_number", length = 10, nullable = false)
+    @Column(name = "reservation_number", length = 17, nullable = false)
     private String reservationNumber;
 
     @Column(name = "phone_number", length = 11, nullable = false)

--- a/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
@@ -5,9 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
-    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END " +
-            "FROM Ticket t WHERE t.event.id = :eventId AND t.phoneNumber = :phoneNumber")
-    boolean existsByEventIdAndPhoneNumber(@Param("eventId") Long eventId, @Param("phoneNumber") String phoneNumber);
+    @Query("SELECT t FROM Ticket t JOIN FETCH t.event WHERE t.event.id = :eventId AND t.phoneNumber = :phoneNumber")
+    Optional<Ticket> findByEventIdAndPhoneNumberWithEvent(@Param("eventId") Long eventId, @Param("phoneNumber") String phoneNumber);
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
@@ -41,7 +41,7 @@ public class TicketService {
     }
 
     private void isExistTicketBy(Long eventId, String phoneNo) {
-        if(ticketRepository.existsByEventIdAndPhoneNumber(eventId, phoneNo)){
+        if(ticketRepository.findByEventIdAndPhoneNumberWithEvent(eventId, phoneNo).isPresent()){
             throw new BaseException(ErrorCode.TICKET_EXIST_BY_PHONENUM);
         }
     }

--- a/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
+++ b/src/main/java/com/festimap/tiketing/global/util/ReservationNumGenerator.java
@@ -10,9 +10,8 @@ import java.util.UUID;
 public class ReservationNumGenerator {
 
     public static String generate(String eventPrefix, int remainingTicket) {
-        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyMMdd"));
         String random = UUID.randomUUID().toString().replace("-", "").substring(0, 5).toUpperCase();
         String formatted = String.format("%04d", remainingTicket);
-        return eventPrefix + date + random + formatted;
+        return eventPrefix + random + formatted;
     }
 }

--- a/src/test/java/com/festimap/tiketing/domain/ticket/dto/TicketRequestTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/dto/TicketRequestTest.java
@@ -1,0 +1,74 @@
+package com.festimap.tiketing.domain.ticket.dto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.util.Set;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class TicketRequestTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void 유효한_입력일_경우_검증_성공() {
+        TicketRequest request = new TicketRequest();
+        setField(request, "eventId", 1L);
+        setField(request, "phoneNumber", "01012345678");
+        setField(request, "ticketCount", 2);
+
+        Set<ConstraintViolation<TicketRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 유효하지_않은_전화번호_형식일_경우_검증_실패(){
+        //given
+        TicketRequest request = new TicketRequest();
+
+        //when
+        setField(request, "eventId", 1L);
+        setField(request, "phoneNumber", "01199998888");
+        setField(request, "ticketCount", 2);
+
+        //then
+        Set<ConstraintViolation<TicketRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("전화번호 형식이 올바르지 않습니다."));
+    }
+
+    @Test
+    void 티켓수량이_범위를_벗어나면_검증_실패() {
+        TicketRequest request = new TicketRequest();
+        setField(request, "eventId", 1L);
+        setField(request, "phoneNumber", "01012345678");
+        setField(request, "ticketCount", 3);
+
+        Set<ConstraintViolation<TicketRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("1~2장만 신청 가능합니다."));
+    }
+
+    @Test
+    void 이벤트ID가_null이면_검증_실패() {
+        TicketRequest request = new TicketRequest();
+        setField(request, "eventId", null);
+        setField(request, "phoneNumber", "01012345678");
+        setField(request, "ticketCount", 1);
+
+        Set<ConstraintViolation<TicketRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("이벤트Id가 누락됐습니다"));
+    }
+}

--- a/src/test/java/com/festimap/tiketing/domain/ticket/repository/TicketRepositoryTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/repository/TicketRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.festimap.tiketing.domain.ticket.repository;
+
+
+import com.festimap.tiketing.domain.event.Event;
+import com.festimap.tiketing.domain.event.dto.EventCreateReqDto;
+import com.festimap.tiketing.domain.event.repository.EventRepository;
+import com.festimap.tiketing.domain.ticket.Ticket;
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SuppressWarnings("NonAsciiCharacters")
+public class TicketRepositoryTest {
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    private Ticket ticket;
+    private Event event;
+
+    @BeforeEach
+    void setUp() {
+        TicketRequest request = new TicketRequest();
+        setField(request, "eventId", 1L);
+        setField(request, "phoneNumber", "01012341234");
+        setField(request, "ticketCount", 2);
+
+        EventCreateReqDto eventCreateReqDto = new EventCreateReqDto(
+                1L,
+                "테스트 이벤트",
+                LocalDateTime.now(),
+                1000
+        );
+        event = Event.from(eventCreateReqDto);
+
+        setField(event, "id", 1L);
+        setField(event, "remainingTickets", 3000);
+        setField(event, "isFinished", false);
+        setField(event, "prefix", "MW");
+        setField(event, "createdAt", LocalDateTime.now());
+        eventRepository.save(event);
+        ticket = Ticket.of(request, event);
+        setField(ticket, "issuedAt", LocalDateTime.now());
+        ticketRepository.save(ticket);
+    }
+
+    @Test
+    void 이벤트ID_유저전화번호_조회_이벤트는_영속성컨텍스트에_있다(){
+        Optional<Ticket> result = ticketRepository.findByEventIdAndPhoneNumberWithEvent(event.getId(), "01012341234");
+        System.out.println("=======================");
+        assertThat(result).isPresent();
+        System.out.println("=======================");
+        assertThat(result.get().getEvent()).isNotNull();
+        System.out.println("=======================");
+        assertThat(result.get().getEvent().getId()).isEqualTo(event.getId());
+        System.out.println("=======================");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #3 

## 📝작업 내용

티켓 중복 확인 쿼리 수정

우선 티켓발급 비즈니스 로직을 살펴보면 다음과 같습니다.
```
 @Transactional
    public void reserve(TicketRequest request) {
        isExistTicketBy(request.getEventId(), request.getPhoneNumber());
        Event event = loadEventOrThrow(request.getEventId());
        Ticket ticket = Ticket.of(request, event);
        ticketRepository.save(ticket);
    }
```
기존 티켓 중복확인 쿼리를 보면
```
@Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END " +
       "FROM Ticket t WHERE t.event.id = :eventId AND t.phoneNumber = :phoneNumber")
```
인데, 비즈니스 로직에서 중복확인을 한 후 Event를 조회하는 쿼리가 한번 더 발생합니다. 왜냐면 기존 쿼리에서는 Event를 영속성 컨텍스트로 가져오지 않기 때문입니다. 이 쿼리는 단순히 존재 여부만 확인하는 count 쿼리인데, `event.id`를 조건절에만 사용하고 있기 때문에 쿼리 실행 결과를 boolean형을 반환합니다.

이에 대해 eventId와 phoneNumber로 Ticket 존재 여부를 확인할 때, Event 엔티티도 함께 영속성 컨텍스트에 로드되도록 fetch join을 적용했습니다.
- 기존 쿼리는 존재 여부만 판단했지만, 이후 로직에서 Event가 필요하여 다시 조회해야 했음
- fetch join을 통해 불필요한 추가 쿼리 방지 및 성능 개선 기대

테스트코드에서 쿼리 확인 결과
```
/* SELECT
        t 
    FROM
        Ticket t 
    JOIN
        FETCH t.event 
    WHERE
        t.event.id = :eventId 
        AND t.phoneNumber = :phoneNumber */ select
            ticket0_.id as id1_1_0_,
            event1_.id as id1_0_1_,
            ticket0_.count as count2_1_0_,
            ticket0_.event_id as event_id6_1_0_,
            ticket0_.issued_at as issued_a3_1_0_,
            ticket0_.phone_number as phone_nu4_1_0_,
            ticket0_.reservation_number as reservat5_1_0_,
            event1_.created_at as created_2_0_1_,
            event1_.festival_id as festival3_0_1_,
            event1_.is_finished as is_finis4_0_1_,
            event1_.name as name5_0_1_,
            event1_.open_at as open_at6_0_1_,
            event1_.prefix as prefix7_0_1_,
            event1_.remaining_tickets as remainin8_0_1_,
            event1_.total_tickets as total_ti9_0_1_ 
        from
            ticket ticket0_ 
        inner join
            event event1_ 
                on ticket0_.event_id=event1_.id 
        where
            ticket0_.event_id=? 
            and ticket0_.phone_number=?

```
로, 추가 조회 쿼리가 나가지 않음을 확인했습니다.

## 💬리뷰 요구사항

성능 개선의 여지가 남아있다면, 알려주세요!
