### PR TITLE
[feat] Event 백오피스 구현

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/event/Event.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/Event.java
@@ -121,7 +121,7 @@ public class Event {
         this.isFinished = false;
     }
 
-    public void softDeleted(){
+    public void softDelete(){
         this.isDeleted = true;
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/event/controller/EventController.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/controller/EventController.java
@@ -1,0 +1,65 @@
+package com.festimap.tiketing.domain.event.controller;
+
+import com.festimap.tiketing.domain.event.dto.*;
+import com.festimap.tiketing.domain.event.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping("/admin/event")
+    public void create(@RequestBody EventCreateReqDto eventCreateReqDto) {
+        eventService.create(eventCreateReqDto);
+    }
+
+    @GetMapping("/admin/events")
+    public List<AdminEventItemDto> getEventsForAdmin(@RequestParam(name = "festivalId") Long festivalId){
+        return eventService.getEventsForAdmin(festivalId);
+    }
+
+    @GetMapping("/admin/event")
+    public AdminEventResDto getEventForAdmin(@RequestParam(name = "id") Long id){
+        return eventService.getEventForAdmin(id);
+    }
+
+    @GetMapping("/event")
+    public UserEventResDto getEventForUser(@RequestParam(name = "id") Long id){
+        return eventService.getEventForUser(id);
+    }
+
+    @PutMapping("/admin/event")
+    public AdminEventResDto updateEventInfo(@RequestParam(name = "id") Long id,
+                                           @RequestBody EventInfoUpdateDto eventInfoUpdateDto){
+        return eventService.updateEventInfoBeforeOpenAt(id,eventInfoUpdateDto);
+    }
+
+    @PatchMapping("/admin/event/name")
+    public AdminEventResDto updateEventName(@RequestParam(name = "id") Long id,
+                                            @RequestBody EventNameUpdateDto eventNameUpdateDto){
+        return eventService.updateEventName(id, eventNameUpdateDto);
+    }
+
+    @PatchMapping("/admin/event/totalTickets")
+    public AdminEventResDto increaseTotalTickets(@RequestParam(name = "id") Long id,
+                                                 @RequestBody EventTotalTicketsUpdateDto eventTotalTicketsUpdateDto){
+        return eventService.increaseEventTotalTickets(id, eventTotalTicketsUpdateDto);
+    }
+
+    @PatchMapping("/admin/event/isFinished")
+    public AdminEventResDto updateEventIsFinished(@RequestParam(name = "id") Long id,
+                                                  @RequestBody EventIsFinishedUpdateDto eventIsFinishedUpdateDto){
+        return eventService.updateEventIsFinished(id, eventIsFinishedUpdateDto);
+    }
+
+    @DeleteMapping("/admin/event")
+    public void delete(@RequestParam(name = "id") Long id){
+        eventService.softDeletedEvent(id);
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/event/dto/AdminEventResDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/dto/AdminEventResDto.java
@@ -22,11 +22,12 @@ public class AdminEventResDto {
     private int remainingTickets;
     private LocalDateTime openAt;
     private boolean isFinished;
+    private String prefix;
     private LocalDateTime createdAt;
 
     @Builder
     private AdminEventResDto(Long id, String name, int totalTickets, int remainingTickets, LocalDateTime openAt,
-                            boolean isFinished, LocalDateTime createdAt) {
+                            boolean isFinished, LocalDateTime createdAt,String prefix) {
         this.id = id;
         this.name = name;
         this.totalTickets = totalTickets;
@@ -34,6 +35,7 @@ public class AdminEventResDto {
         this.openAt = openAt;
         this.isFinished = isFinished;
         this.createdAt = createdAt;
+        this.prefix = prefix;
     }
 
     public static AdminEventResDto from(Event event) {
@@ -45,6 +47,7 @@ public class AdminEventResDto {
                 .openAt(event.getOpenAt())
                 .isFinished(event.isFinished())
                 .createdAt(event.getCreatedAt())
+                .prefix(event.getPrefix())
                 .build();
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/event/dto/EventCreateReqDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/dto/EventCreateReqDto.java
@@ -12,11 +12,13 @@ public class EventCreateReqDto {
     private String name;
     private LocalDateTime openAt;
     private int totalTickets;
+    private String prefix;
 
-    public EventCreateReqDto(Long festivalId, String name, LocalDateTime openAt, int totalTickets) {
+    public EventCreateReqDto(Long festivalId, String name, LocalDateTime openAt, int totalTickets, String prefix) {
         this.festivalId = festivalId;
         this.name = name;
         this.openAt = openAt;
         this.totalTickets = totalTickets;
+        this.prefix = prefix;
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/event/dto/EventInfoUpdateDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/dto/EventInfoUpdateDto.java
@@ -1,0 +1,16 @@
+package com.festimap.tiketing.domain.event.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class EventInfoUpdateDto {
+    private String name;
+    private int totalTickets;
+    private LocalDateTime openAt;
+    private String prefix;
+}

--- a/src/main/java/com/festimap/tiketing/domain/event/dto/EventIsFinishedUpdateDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/dto/EventIsFinishedUpdateDto.java
@@ -1,0 +1,10 @@
+package com.festimap.tiketing.domain.event.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EventIsFinishedUpdateDto {
+    private boolean isFinished;
+}

--- a/src/main/java/com/festimap/tiketing/domain/event/dto/EventNameUpdateDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/dto/EventNameUpdateDto.java
@@ -1,0 +1,10 @@
+package com.festimap.tiketing.domain.event.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EventNameUpdateDto {
+    private String name;
+}

--- a/src/main/java/com/festimap/tiketing/domain/event/dto/EventTotalTicketsUpdateDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/dto/EventTotalTicketsUpdateDto.java
@@ -1,0 +1,10 @@
+package com.festimap.tiketing.domain.event.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EventTotalTicketsUpdateDto {
+    private int increaseAmount;
+}

--- a/src/main/java/com/festimap/tiketing/domain/event/service/EventService.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/service/EventService.java
@@ -1,0 +1,82 @@
+package com.festimap.tiketing.domain.event.service;
+
+import com.festimap.tiketing.domain.event.Event;
+import com.festimap.tiketing.domain.event.dto.*;
+import com.festimap.tiketing.domain.event.exception.EventNotFoundException;
+import com.festimap.tiketing.domain.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    @Transactional
+    public void create(EventCreateReqDto eventCreateReqDto){
+        eventRepository.save(Event.from(eventCreateReqDto));
+    }
+
+    // TODO: 페이징 적용
+    @Transactional(readOnly = true)
+    public List<AdminEventItemDto> getEventsForAdmin(Long festivalId){
+        return eventRepository.findAllByFestivalId(festivalId).stream()
+                .map(AdminEventItemDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public AdminEventResDto getEventForAdmin(Long id){
+        Event event = loadEventOrThrow(id);
+        return AdminEventResDto.from(event);
+    }
+
+    @Transactional(readOnly = true)
+    public UserEventResDto getEventForUser(Long id){
+        Event event = loadEventOrThrow(id);
+        return UserEventResDto.from(event);
+    }
+
+    @Transactional
+    public AdminEventResDto updateEventInfoBeforeOpenAt(Long id, EventInfoUpdateDto eventInfoUpdateDto){
+        Event event = loadEventOrThrow(id);
+        event.updateEventInfo(eventInfoUpdateDto);
+        return AdminEventResDto.from(event);
+    }
+
+    @Transactional
+    public AdminEventResDto updateEventName(Long id, EventNameUpdateDto eventNameUpdateDto){
+        Event event = loadEventOrThrow(id);
+        event.updateName(eventNameUpdateDto);
+        return AdminEventResDto.from(event);
+    }
+
+    @Transactional
+    public AdminEventResDto increaseEventTotalTickets(Long id, EventTotalTicketsUpdateDto eventTotalTicketsUpdateDto){
+        Event event = loadEventOrThrow(id);
+        event.increaseTotalTickets(eventTotalTicketsUpdateDto);
+        return AdminEventResDto.from(event);
+    }
+
+    @Transactional
+    public AdminEventResDto updateEventIsFinished(Long id, EventIsFinishedUpdateDto eventIsFinishedUpdateDto){
+        Event event = loadEventOrThrow(id);
+        event.updateIsFinished(eventIsFinishedUpdateDto);
+        return AdminEventResDto.from(event);
+    }
+
+    @Transactional
+    public void softDeletedEvent(Long id){
+        Event event = loadEventOrThrow(id);
+        event.softDeleted();
+    }
+
+    private Event loadEventOrThrow(Long id){
+        return eventRepository.findById(id).orElseThrow(()->new EventNotFoundException(id));
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/event/service/EventService.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/service/EventService.java
@@ -73,7 +73,7 @@ public class EventService {
     @Transactional
     public void softDeletedEvent(Long id){
         Event event = loadEventOrThrow(id);
-        event.softDeleted();
+        event.softDelete();
     }
 
     private Event loadEventOrThrow(Long id){

--- a/src/main/java/com/festimap/tiketing/global/config/security/AuthorizationConfig.java
+++ b/src/main/java/com/festimap/tiketing/global/config/security/AuthorizationConfig.java
@@ -11,6 +11,7 @@ public class AuthorizationConfig {
         http.authorizeRequests()
                 .antMatchers(SecurityConstants.SWAGGER_URLS).permitAll()
                 .antMatchers(SecurityConstants.PUBLIC_POST_URLS).permitAll()
+                .antMatchers(SecurityConstants.PUBLIC_GET_URLS).permitAll()
                 .anyRequest().authenticated();
     }
 }

--- a/src/main/java/com/festimap/tiketing/global/constants/SecurityConstants.java
+++ b/src/main/java/com/festimap/tiketing/global/constants/SecurityConstants.java
@@ -13,4 +13,8 @@ public class SecurityConstants {
             "/api/verification/send/code",
             "/api/verification/check/code",
     };
+
+    public static final String[] PUBLIC_GET_URLS = {
+            "/api/event"
+    };
 }

--- a/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
+++ b/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
@@ -37,6 +37,11 @@ public enum ErrorCode {
     TICKET_EXIST_BY_PHONENUM("T002", "Ticket Exist By Phone Number",400),
     TICKET_SOLD_OUT("T003", "Not enough tickets remaining", 400),
 
+    // Event
+    EVENT_ALREADY_OPEN("EVT001", "Cannot modify event after open time", 400),
+    NO_REMAINING_TICKETS("EVT002", "Cannot reopen event: no remaining tickets", 400),
+
+
     ;
 
     private final String code;

--- a/src/test/java/com/festimap/tiketing/domain/event/EventTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/event/EventTest.java
@@ -158,7 +158,7 @@ public class EventTest {
     @Test
     void event_softDeleted_테스트(){
         //wehn
-        event.softDeleted();
+        event.softDelete();
 
         //then
         assertThat(event.isDeleted()).isTrue();

--- a/src/test/java/com/festimap/tiketing/domain/event/EventTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/event/EventTest.java
@@ -1,0 +1,166 @@
+package com.festimap.tiketing.domain.event;
+
+import com.festimap.tiketing.domain.event.dto.*;
+import com.festimap.tiketing.global.error.ErrorCode;
+import com.festimap.tiketing.global.error.exception.BaseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class EventTest {
+
+    private Event event;
+    private EventCreateReqDto eventCreateReqDto;
+
+    @BeforeEach
+    void setUp() {
+        eventCreateReqDto = new EventCreateReqDto();
+        setField(eventCreateReqDto,"festivalId",1L);
+        setField(eventCreateReqDto,"name","이벤트1");
+        setField(eventCreateReqDto,"openAt", LocalDateTime.now().plusMinutes(5));
+        setField(eventCreateReqDto,"totalTickets",10);
+        setField(eventCreateReqDto,"prefix","MW");
+
+        event = Event.from(eventCreateReqDto);
+    }
+
+    @Test
+    void 정적팩토리메서드_생성_테스트(){
+        //when
+        Event event1 = Event.from(eventCreateReqDto);
+
+        //then
+        assertThat(event1).isNotNull();
+        assertThat(event1.getFestivalId()).isEqualTo(1L);
+        assertThat(event1.getOpenAt()).isAfter(LocalDateTime.now());
+        assertThat(event1.getTotalTickets()).isEqualTo(10);
+        assertThat(event1.getPrefix()).isEqualTo("MW");
+        assertThat(event1.isFinished()).isFalse();
+        assertThat(event1.isDeleted()).isFalse();
+    }
+
+    @Test
+    void remainingTickets_필드_감소_테스트(){
+        //when
+        event.decreaseRemainingTickets(2);
+
+        //then
+        assertThat(event.getRemainingTickets()).isEqualTo(8);
+        assertThat(event.getTotalTickets()).isEqualTo(10);
+    }
+
+    @Test
+    void remainingTickets_필드_감소_실패_테스트(){
+        //when
+        assertThatThrownBy(() -> event.decreaseRemainingTickets(11))
+                .isInstanceOf(BaseException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TICKET_SOLD_OUT);
+    }
+
+    @Test
+    void event_정보_전체_수정_테스트(){
+        //given
+        EventInfoUpdateDto eventInfoUpdateDto = new EventInfoUpdateDto();
+        setField(eventInfoUpdateDto,"name","수정된 이름");
+        setField(eventInfoUpdateDto,"openAt",LocalDateTime.now().plusMinutes(10));
+        setField(eventInfoUpdateDto,"totalTickets",20);
+        setField(eventInfoUpdateDto,"prefix","AB");
+
+        //when
+        event.updateEventInfo(eventInfoUpdateDto);
+
+        //then
+        assertThat(event).isNotNull();
+        assertThat(event.getName()).isEqualTo("수정된 이름");
+        assertThat(event.getFestivalId()).isEqualTo(1L);
+        assertThat(event.getOpenAt()).isAfter(LocalDateTime.now().plusMinutes(5));
+        assertThat(event.getTotalTickets()).isEqualTo(20);
+        assertThat(event.getPrefix()).isEqualTo("AB");
+    }
+
+    @Test
+    void event_정보_수정_실패_테스트(){
+        //given
+        setField(event,"openAt",LocalDateTime.now().minusMinutes(10));
+        EventInfoUpdateDto eventInfoUpdateDto = new EventInfoUpdateDto();
+        setField(eventInfoUpdateDto,"name","수정된 이름");
+        setField(eventInfoUpdateDto,"openAt",LocalDateTime.now().plusMinutes(10));
+        setField(eventInfoUpdateDto,"totalTickets",20);
+        setField(eventInfoUpdateDto,"prefix","AB");
+
+        //when & then
+        assertThatThrownBy(() -> event.updateEventInfo(eventInfoUpdateDto))
+                .isInstanceOf(BaseException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EVENT_ALREADY_OPEN);
+    }
+
+    @Test
+    void event_이름_수정_테스트(){
+        //given
+        EventNameUpdateDto eventNameUpdateDto = new EventNameUpdateDto();
+        setField(eventNameUpdateDto,"name","수정된 이름");
+
+        //when
+        event.updateName(eventNameUpdateDto);
+
+        //then
+        assertThat(event.getName()).isEqualTo("수정된 이름");
+    }
+
+    @Test
+    void event_전체티켓수_증가_테스트(){
+        // given
+        EventTotalTicketsUpdateDto eventTotalTicketsUpdateDto = new EventTotalTicketsUpdateDto();
+        setField(eventTotalTicketsUpdateDto,"increaseAmount",20);
+
+        // when
+        event.increaseTotalTickets(eventTotalTicketsUpdateDto);
+
+        // then
+        assertThat(event.getTotalTickets()).isEqualTo(30);
+    }
+
+    @Test
+    void event_isFinished_변경_성공_테스트(){
+        // given
+        EventIsFinishedUpdateDto eventIsFinishedUpdateDto = new EventIsFinishedUpdateDto();
+        setField(eventIsFinishedUpdateDto,"isFinished",true);
+
+        // when
+        event.updateIsFinished(eventIsFinishedUpdateDto);
+
+        // then
+        assertThat(event.isFinished()).isTrue();
+    }
+
+    @Test
+    void event_isFinished_변경_실패_테스트(){
+        //given
+        setField(event,"remainingTickets",0);
+        EventIsFinishedUpdateDto eventIsFinishedUpdateDto = new EventIsFinishedUpdateDto();
+        setField(eventIsFinishedUpdateDto,"isFinished",false);
+
+        //when & then
+        assertThatThrownBy(() -> event.updateIsFinished(eventIsFinishedUpdateDto))
+                .isInstanceOf(BaseException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NO_REMAINING_TICKETS);
+    }
+
+    @Test
+    void event_softDeleted_테스트(){
+        //wehn
+        event.softDeleted();
+
+        //then
+        assertThat(event.isDeleted()).isTrue();
+    }
+}

--- a/src/test/java/com/festimap/tiketing/domain/event/repository/EventRepositoryTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/event/repository/EventRepositoryTest.java
@@ -1,0 +1,133 @@
+package com.festimap.tiketing.domain.event.repository;
+
+import com.festimap.tiketing.domain.event.Event;
+import com.festimap.tiketing.domain.event.dto.EventCreateReqDto;
+import com.festimap.tiketing.domain.verification.Verification;
+import com.festimap.tiketing.domain.verification.dto.VerificationReqDto;
+import com.festimap.tiketing.domain.verification.repository.VerificationRepository;
+import com.festimap.tiketing.global.testsupport.TestTxManagerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.persistence.QueryTimeoutException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@ExtendWith(SpringExtension.class)
+@Disabled
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SuppressWarnings("NonAsciiCharacters")
+public class EventRepositoryTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Event event;
+    private EventCreateReqDto eventCreateReqDto;
+
+    @BeforeEach
+    void setUp() {
+        eventCreateReqDto = new EventCreateReqDto();
+        setField(eventCreateReqDto,"festivalId",1L);
+        setField(eventCreateReqDto,"name","이벤트1");
+        setField(eventCreateReqDto,"openAt", LocalDateTime.now().plusMinutes(5));
+        setField(eventCreateReqDto,"totalTickets",10);
+        setField(eventCreateReqDto,"prefix","MW");
+        event = Event.from(eventCreateReqDto);
+        setField(event,"createdAt",LocalDateTime.now());
+
+        event = eventRepository.save(event);
+    }
+
+    @Test
+    void festivalId로_이벤트_목록_조회시_저장된_엔티티_반환() {
+        // when
+        List<Event> result = eventRepository.findAllByFestivalId(1L);
+
+        // then
+        assertThat(result)
+                .hasSize(1)
+                .first()
+                .extracting(Event::getId)
+                .isEqualTo(event.getId());
+    }
+
+    @Test
+    void id로_비관적_락을_획득_조회시_엔티티_반환() {
+        // when
+        Optional<Event> found = eventRepository.findByIdWithLock(event.getId());
+
+        // then
+        assertThat(found).isPresent().hasValueSatisfying(e ->
+                        assertThat(e.getId()).isEqualTo(event.getId()));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void 동시_비관적락_획득_시_두번째_트랜잭션은_타임아웃_예외() throws Exception {
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // -------- ① 첫 번째 트랜잭션 : 락 점유 후 12초 대기 -----------------
+        executor.submit(() -> {
+            TransactionTemplate tx = new TransactionTemplate(txManager);
+            tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            tx.executeWithoutResult(status -> {
+                eventRepository.findByIdWithLock(event.getId()).orElseThrow();
+                latch.countDown();
+                try {
+                    Thread.sleep(12_000);
+                } catch (InterruptedException ignored) {
+
+                }
+            });
+        });
+
+        // -------- ② 두 번째 트랜잭션 : 락 획득 시도 -------------------------
+        Future<Throwable> future = executor.submit(() -> {
+            latch.await();
+            TransactionTemplate tx = new TransactionTemplate(txManager);
+            tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            try {
+                tx.executeWithoutResult(s ->
+                        eventRepository.findByIdWithLock(event.getId()));
+                return null;
+            } catch (Throwable t) {
+                return t;
+            }
+        });
+
+        Throwable thrown = future.get(15, TimeUnit.SECONDS);
+        executor.shutdownNow();
+
+        assertThat(thrown)
+                .isNotNull()
+                .satisfies(t -> assertThat(t)
+                        .isInstanceOfAny(TransactionSystemException.class));
+    }
+}

--- a/src/test/java/com/festimap/tiketing/domain/event/repository/EventRepositoryTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/event/repository/EventRepositoryTest.java
@@ -2,10 +2,6 @@ package com.festimap.tiketing.domain.event.repository;
 
 import com.festimap.tiketing.domain.event.Event;
 import com.festimap.tiketing.domain.event.dto.EventCreateReqDto;
-import com.festimap.tiketing.domain.verification.Verification;
-import com.festimap.tiketing.domain.verification.dto.VerificationReqDto;
-import com.festimap.tiketing.domain.verification.repository.VerificationRepository;
-import com.festimap.tiketing.global.testsupport.TestTxManagerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -13,9 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.dao.PessimisticLockingFailureException;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -24,7 +17,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import javax.persistence.QueryTimeoutException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/com/festimap/tiketing/domain/ticket/service/TicketConcurrencyTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/service/TicketConcurrencyTest.java
@@ -44,7 +44,7 @@ public class TicketConcurrencyTest {
         eventRepository.deleteAll();
 
         EventCreateReqDto eventCreateReqDto =
-                new EventCreateReqDto(1L,"1차 예매", LocalDateTime.now(),10);
+                new EventCreateReqDto(1L,"1차 예매", LocalDateTime.now(),10,"MW");
 
         event = eventRepository.save(Event.from(eventCreateReqDto));
     }

--- a/src/test/java/com/festimap/tiketing/domain/verification/service/VerificationServiceTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/verification/service/VerificationServiceTest.java
@@ -60,7 +60,7 @@ public class VerificationServiceTest {
         verification = Verification.from(verificationReqDto);
         verification.updateVerificationCode();
         EventCreateReqDto eventCreateReqDto =
-                new EventCreateReqDto(1L,"1차 예매", LocalDateTime.now(),10);
+                new EventCreateReqDto(1L,"1차 예매", LocalDateTime.now(),10,"MW");
         event = Event.from(eventCreateReqDto);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #15 

## 📝작업 내용

1. Event 단일 조회시 User와 Admin의 api를 다르게 설정해서 User에게는 필요하지 않은 정보를 제공하지 않도록 구현하였습니다.
2. 수정의 경우 open_at 시점에 따라서 전체 수정 가능/ 불가능을 나누고 open_at 이후부터는 이름, 총 티켓수, isFinished만 수정할 수 있도록 단일 수정 api를 구현하였습니다.
```
- 전체수정 -> PUT 메서드
- 단일 수정 -> PATCH 메서드
```
3. 삭제의 경우 event만 일단 softDeleted 처리로 구현하였습니다. 따라서 이후 연관된 엔티티들은 어떻게 설정할지 고려해야합니다.
4. Event의 필드와 관련된 책임을 모두 Event 클래스에 부여해 엔티티의 책임을 다하도록 구현하였습니다.
5. Lock을 걸어서 조회하는 쿼리의 경우 query.timeout이 제대로 동작하는지 확인하기 위해 EventRepositoryTest에 테스트코드를 작성하여 확인하였습니다.


## 추가 구현 해야할 사항

1. softDeleted를 사용할 떄 조회시에는 isDeleted=false인 데이터만 조회하도록 수정해야합니다.
2. EventController의 Validation을 추가해야합니다.

