### PR TITLE
[fix] 티켓 발급 요청 시 검증 로직 추가

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/event/Event.java
+++ b/src/main/java/com/festimap/tiketing/domain/event/Event.java
@@ -81,4 +81,16 @@ public class Event {
         }
         this.remainingTickets -= quantity;
     }
+
+    public void isOpen(){
+        if(!LocalDateTime.now().isAfter(openAt)){
+            throw new BaseException(ErrorCode.TICKET_SERVER_NOT_OPEN);
+        }
+    }
+
+    public void isRemainingTicketLeft(){
+        if(remainingTickets <= 0){
+            throw new BaseException(ErrorCode.TICKET_SOLD_OUT);
+        }
+    }
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
@@ -1,6 +1,7 @@
 package com.festimap.tiketing.domain.ticket.controller;
 
 import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.domain.ticket.service.TicketService;
 import com.festimap.tiketing.global.error.ErrorCode;
 import com.festimap.tiketing.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 @RestController
@@ -18,13 +18,14 @@ import java.util.concurrent.atomic.AtomicLong;
 @RequestMapping("/api")
 public class TicketController {
 
-    private final BlockingQueue<TicketRequest> ticketQueue;
+    private final TicketService ticketService;
     private AtomicLong requestOrder = new AtomicLong(0);
 
     @PostMapping("/tickets/apply")
     public void apply(@Validated @RequestBody TicketRequest request) {
-        if (requestOrder.incrementAndGet() > 2400 || !ticketQueue.offer(request)) {
+        if (requestOrder.incrementAndGet() > 2400) {
             throw new BaseException(ErrorCode.TICKET_RESERVATION_CLOSED);
         }
+        ticketService.offerQueue(request);
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketService.java
@@ -9,20 +9,34 @@ import com.festimap.tiketing.domain.ticket.repository.TicketRepository;
 import com.festimap.tiketing.global.error.ErrorCode;
 import com.festimap.tiketing.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.concurrent.BlockingQueue;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TicketService {
 
     private final TicketRepository ticketRepository;
     private final EventRepository eventRepository;
+    private final BlockingQueue<TicketRequest> ticketQueue;
+
+    @Transactional
+    public void offerQueue(TicketRequest request){
+        Event event = loadEventOrThrow(request.getEventId());
+        event.isOpen();
+        event.isRemainingTicketLeft();
+        canOfferQueue(request);
+    }
 
     @Transactional
     public void reserve(TicketRequest request) {
         isExistTicketBy(request.getEventId(), request.getPhoneNumber());
         Event event = loadEventOrThrow(request.getEventId());
+        event.decreaseRemainingTickets(request.getTicketCount());
         Ticket ticket = Ticket.of(request, event);
         ticketRepository.save(ticket);
     }
@@ -30,19 +44,30 @@ public class TicketService {
     @Transactional
     public void reserveWithLock(TicketRequest request) {
         isExistTicketBy(request.getEventId(), request.getPhoneNumber());
-        Event event = loadEventOrThrow(request.getEventId());
+        Event event = loadEventWithLockOrThrow(request.getEventId());
         event.decreaseRemainingTickets(request.getTicketCount());
         ticketRepository.save(Ticket.of(request,event));
     }
 
-    private Event loadEventOrThrow(Long eventId) {
+    private Event loadEventWithLockOrThrow(Long eventId) {
         return eventRepository.findByIdWithLock(eventId)
+                .orElseThrow(() -> new EventNotFoundException(eventId));
+    }
+
+    private Event loadEventOrThrow(Long eventId){
+        return eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventNotFoundException(eventId));
     }
 
     private void isExistTicketBy(Long eventId, String phoneNo) {
         if(ticketRepository.findByEventIdAndPhoneNumberWithEvent(eventId, phoneNo).isPresent()){
             throw new BaseException(ErrorCode.TICKET_EXIST_BY_PHONENUM);
+        }
+    }
+
+    private void canOfferQueue(TicketRequest request) {
+        if(!ticketQueue.offer(request)){
+            throw new BaseException(ErrorCode.TICKET_RESERVATION_CLOSED);
         }
     }
 }

--- a/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
+++ b/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     TICKET_RESERVATION_CLOSED("T001", "Ticket Reservation Closed",429),
     TICKET_EXIST_BY_PHONENUM("T002", "Ticket Exist By Phone Number",400),
     TICKET_SOLD_OUT("T003", "Not enough tickets remaining", 400),
-
+    TICKET_SERVER_NOT_OPEN("T004", "Reserving ticket is not available", 400)
     ;
 
     private final String code;

--- a/src/test/java/com/festimap/tiketing/domain/ticket/service/TickerServiceTest.java
+++ b/src/test/java/com/festimap/tiketing/domain/ticket/service/TickerServiceTest.java
@@ -1,0 +1,114 @@
+package com.festimap.tiketing.domain.ticket.service;
+
+import com.festimap.tiketing.domain.event.Event;
+import com.festimap.tiketing.domain.event.dto.EventCreateReqDto;
+import com.festimap.tiketing.domain.event.repository.EventRepository;
+import com.festimap.tiketing.domain.ticket.Ticket;
+import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.domain.ticket.repository.TicketRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.swing.text.html.Option;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+public class TickerServiceTest {
+
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private BlockingQueue<TicketRequest> ticketQueue;
+
+    @InjectMocks
+    private TicketService ticketService;
+
+    private Event event;
+    private Ticket ticket;
+
+    @BeforeEach
+    void setUp() {
+
+        TicketRequest request = new TicketRequest();
+        setField(request, "eventId", 1L);
+        setField(request, "phoneNumber", "01012341234");
+        setField(request, "ticketCount", 2);
+
+        EventCreateReqDto eventCreateReqDto = new EventCreateReqDto(
+                1L,
+                "테스트 이벤트",
+                LocalDateTime.of(2025, 4,13, 12, 0),
+                1000
+        );
+        event = Event.from(eventCreateReqDto);
+        setField(event, "id", 1L);
+        setField(event, "remainingTickets", 3000);
+        setField(event, "isFinished", false);
+        setField(event, "prefix", "MW");
+        setField(event, "createdAt", LocalDateTime.now());
+        eventRepository.save(event);
+        ticket = Ticket.of(request, event);
+        setField(ticket, "issuedAt", LocalDateTime.now());
+        ticketRepository.save(ticket);
+    }
+
+    @Test
+    void 큐에_요청이_성공적으로_추가되는지_검증(){
+        //given
+        given(eventRepository.findById(anyLong())).willReturn(Optional.of(event));
+        TicketRequest clientRequest = new TicketRequest();
+        setField(clientRequest, "eventId", 1L);
+        setField(clientRequest, "phoneNumber", "01012341234");
+        setField(clientRequest, "ticketCount", 2);
+        given(ticketQueue.offer(clientRequest)).willReturn(true);
+
+        //when
+        ticketService.offerQueue(clientRequest);
+
+        //then
+        verify(ticketQueue, times(1)).offer(any());
+    }
+
+    @Test
+    void 요청이_큐에_정상적으로_들어갔는지_직접_확인(){
+        //given
+        given(eventRepository.findById(anyLong())).willReturn(Optional.of(event));
+        TicketRequest clientRequest = new TicketRequest();
+        setField(clientRequest, "eventId", 1L);
+        setField(clientRequest, "phoneNumber", "01012341234");
+        setField(clientRequest, "ticketCount", 2);
+        ticketQueue = new ArrayBlockingQueue<>(100);
+        setField(ticketService, "ticketQueue", ticketQueue);
+
+        //when
+        System.out.println("전 : 요청 큐 크기 : " + ticketQueue.size());
+        ticketService.offerQueue(clientRequest);
+        System.out.println("후 : 요청 큐 크기 : " + ticketQueue.size());
+
+        // then
+        assertThat(ticketQueue).contains(clientRequest);
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #3 

## 📝작업 내용

티켓 발급 요청 시 검증 로직 추가
- openAt 검증 : 이벤트가 열렸는지 검증
- remainingTicket 검증 : 티켓팅이 끝난 후 요청 큐에 진입할 순 있지만 여석이 없다면 큐에 진입하지 못하도록 검증