### PR TITLE
[fix] : cors 도메인 추가 및 withcredentials 헤더 허용

### DIFF
--- a/src/main/java/com/festimap/tiketing/global/config/security/CorsConfig.java
+++ b/src/main/java/com/festimap/tiketing/global/config/security/CorsConfig.java
@@ -24,7 +24,9 @@ public class CorsConfig {
             "https://adelante.wabauniv.com",
             "http://m.localhost:3000",
             "https://firefestivaljeju.com",
-            "https://m.firefestivaljeju.com"
+            "https://m.firefestivaljeju.com",
+            "https://mokpowshow.co.kr",
+            "https://m.mokpowshow.co.kr"
     );
 
     @Bean
@@ -33,7 +35,7 @@ public class CorsConfig {
 
         configuration.setAllowedOrigins(ALLOWED_ORIGINS);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
-        configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization", "X-Requested-With"));
+        configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization", "X-Requested-With","withcredentials"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
## #️⃣연관된 이슈

- #31 

## 📝작업 내용

- CORS 도메인을 추가하고 요청 헤더에 withcredentials을 추가했지만 허용 헤더에 포함되어있지 않아 CORS 문제가 발생하고 있어서 해당 부분을 수정하였습니다.
