### PR TITLE
[feat] : TimeZone 설정 코드 추가

### DIFF
--- a/src/main/java/com/festimap/tiketing/global/config/TimeZoneConfig.java
+++ b/src/main/java/com/festimap/tiketing/global/config/TimeZoneConfig.java
@@ -1,0 +1,21 @@
+package com.festimap.tiketing.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+@Component
+@Slf4j
+public class TimeZoneConfig {
+
+    @PostConstruct
+    public void setupDefaultTimeZone() {
+        ZoneId before = ZoneId.systemDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        ZoneId after = ZoneId.systemDefault();
+        log.info("JVM Default TimeZone {}→{}", before, after);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #33 

## 📝작업 내용

`문제`

event를 새로 생성할 때 아래와 같이 post 요청을 보내게 되면 db에 저장되는 시간은 다음과 같았습니다.

![image](https://github.com/user-attachments/assets/fa77b309-ada9-4b51-8b0b-8eb1b0a1b81f)

![image](https://github.com/user-attachments/assets/84538a2c-5f56-4e27-a1be-33c303a6aaed)

CreateDate 어노테이션으로 저장되는 경우 시간이 한국시간대로 저장되는데 Request로 보낸 날짜의 경우 9시간이 더해져 저장되고 있었습니다.

`원인`

원인을 p6spy로 살펴보았는데 default time zone 설정이 서로 맞지 않아서 발생하는 문제였습니다.

예를 들어, dbc:mysql://localhost:3306/ticketing?serverTimezone=Asia/Seoul 처럼 datasource 설정은 한국시간이지만 
서버의 timezone은 UTC라면 UTC -> KST로 동작하기 때문에 9시간이 더해져서 저장되고 있었습니다.

LocalDateTime.now()를 사용할 때는 따라서 운이 좋게도 UTC -> KST로 저장되고 있었기 때문에 문제가 발생하지 않고 있었습니다.

`해결`

따라서, 모든 time zone을 KST로 변경하는것으로 수정하였습니다. 우분투에서 돌아가는 jvm의 기본 time zone은 UTC이기 때문에 발생하는 문제였고 Spring 컨테이너에 빈이 등록되는 시점에 default time zone을 KST로 바꾸도록 설정하였습니다.

[서버 JVM 시간대]
![image](https://github.com/user-attachments/assets/450d7909-082c-43f5-9917-3e7288303403)


