### PR TITLE
[feature] 비회원 티켓팅 조회/취소 기능 추가

### DIFF
--- a/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/Ticket.java
@@ -2,6 +2,8 @@ package com.festimap.tiketing.domain.ticket;
 
 import com.festimap.tiketing.domain.event.Event;
 import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.global.error.ErrorCode;
+import com.festimap.tiketing.global.error.exception.BaseException;
 import com.festimap.tiketing.global.util.ReservationNumGenerator;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,6 +39,9 @@ public class Ticket {
     @Column(name = "phone_number", length = 11, nullable = false)
     private String phoneNumber;
 
+    @Column(name = "is_canceled", nullable = false)
+    private boolean isCanceled = false;
+
     @Column(name = "issued_at", nullable = false)
     @CreatedDate
     private LocalDateTime issuedAt;
@@ -59,5 +64,14 @@ public class Ticket {
                 .phoneNo(ticketRequest.getPhoneNumber())
                 .event(event)
                 .build();
+    }
+
+    public void cancelTicket(){
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadline = event.getOpenAt().plusDays(3);
+        if(now.isAfter(deadline)){
+            throw new BaseException(ErrorCode.TICKET_CANCELLATION_WINDOW_EXPIRED);
+        }
+        this.isCanceled = true;
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/controller/TicketController.java
@@ -2,15 +2,22 @@ package com.festimap.tiketing.domain.ticket.controller;
 
 import com.festimap.tiketing.domain.ticket.TicketingStrategy;
 import com.festimap.tiketing.domain.ticket.dto.TicketRequest;
+import com.festimap.tiketing.domain.ticket.dto.TicketResDto;
 import com.festimap.tiketing.domain.ticket.service.QueueBasedTicketService;
+import com.festimap.tiketing.domain.ticket.service.TicketGuestService;
 import com.festimap.tiketing.domain.ticket.service.TicketService;
 import com.festimap.tiketing.domain.ticket.service.TicketServiceFactory;
+import com.festimap.tiketing.domain.ticket.util.GuestPhone;
 import com.festimap.tiketing.domain.ticket.util.TicketStrategyHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -18,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class TicketController {
 
     private final TicketServiceFactory ticketServiceFactory;
+    private final TicketGuestService ticketGuestService;
     private final TicketStrategyHolder strategyHolder;
 
     @PostMapping("/ticket/strategy")
@@ -37,5 +45,17 @@ public class TicketController {
         TicketingStrategy strategy = strategyHolder.getStrategy();
         TicketService service = ticketServiceFactory.getService(strategy);
         service.reserve(request);
+    }
+
+    @GetMapping("/guest/tickets")
+    public List<TicketResDto> getReservedTickets(@RequestParam("festivalId") Long festivalId,
+                                                 @GuestPhone String phoneNumber){
+        return ticketGuestService.getGuestTickets(festivalId, phoneNumber);
+    }
+
+    @DeleteMapping("/guest/tickets/{reservationNumber}")
+    public void deleteReservation(@PathVariable("reservationNumber") String reservationNumber,
+                                  @GuestPhone String phoneNumber) {
+        ticketGuestService.deleteReservation(reservationNumber);
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketResDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/dto/TicketResDto.java
@@ -1,0 +1,37 @@
+package com.festimap.tiketing.domain.ticket.dto;
+
+
+import com.festimap.tiketing.domain.ticket.Ticket;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TicketResDto {
+
+    private String phoneNumber;
+    private String reservationNumber;
+    private String eventName;
+    private int count;
+    private boolean isCanceled;
+
+    @Builder
+    private TicketResDto(String phoneNumber, String reservationNumber, String eventName,
+                         int count, boolean isCanceled) {
+        this.phoneNumber = phoneNumber;
+        this.reservationNumber = reservationNumber;
+        this.eventName = eventName;
+        this.count = count;
+    }
+
+    public static TicketResDto from(Ticket ticket) {
+        return TicketResDto.builder()
+                .phoneNumber(ticket.getPhoneNumber())
+                .reservationNumber(ticket.getReservationNumber())
+                .count(ticket.getCount())
+                .eventName(ticket.getEvent().getName())
+                .isCanceled(ticket.isCanceled())
+                .build();
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/exception/TicketNotFoundException.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/exception/TicketNotFoundException.java
@@ -1,0 +1,9 @@
+package com.festimap.tiketing.domain.ticket.exception;
+
+import com.festimap.tiketing.global.error.exception.EntityNotFoundException;
+
+public class TicketNotFoundException extends EntityNotFoundException {
+    public TicketNotFoundException(String reservationNumber) {
+        super(String.format("Ticket with %s is not found", reservationNumber));
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/repository/TicketRepository.java
@@ -5,10 +5,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     @Query("SELECT t FROM Ticket t JOIN FETCH t.event WHERE t.event.id = :eventId AND t.phoneNumber = :phoneNumber")
-    Optional<Ticket> findByEventIdAndPhoneNumberWithEvent(@Param("eventId") Long eventId, @Param("phoneNumber") String phoneNumber);
+    Optional<Ticket> findByEventIdAndPhoneNumberWithEvent(@Param("eventId") Long eventId,
+                                                          @Param("phoneNumber") String phoneNumber);
+
+    @Query("SELECT t FROM Ticket t JOIN t.event e WHERE e.festivalId = :festivalId and t.phoneNumber = :phoneNumber ")
+    List<Ticket> findAllByFestivalIdAndPhoneNumber(@Param("festivalId") Long festivalId,
+                                                   @Param("phoneNumber") String phoneNumber);
+
+    @Query("SELECT t FROM Ticket t WHERE t.reservationNumber = :reservationNumber ")
+    Optional<Ticket> findByReservationNumber(@Param("reservationNumber") String reservationNumber);
 }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketGuestService.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/service/TicketGuestService.java
@@ -1,0 +1,37 @@
+package com.festimap.tiketing.domain.ticket.service;
+
+import com.festimap.tiketing.domain.ticket.Ticket;
+import com.festimap.tiketing.domain.ticket.dto.TicketResDto;
+import com.festimap.tiketing.domain.ticket.exception.TicketNotFoundException;
+import com.festimap.tiketing.domain.ticket.repository.TicketRepository;
+import com.festimap.tiketing.global.error.ErrorCode;
+import com.festimap.tiketing.global.error.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TicketGuestService {
+
+    private final TicketRepository ticketRepository;
+
+    public List<TicketResDto> getGuestTickets(Long festivalId, String phoneNumber){
+        List<Ticket> tickets = ticketRepository.findAllByFestivalIdAndPhoneNumber(festivalId,phoneNumber);
+        return tickets.stream()
+                .map(TicketResDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    //TODO : 티켓 취소 가능 날짜 관련 개선 필요
+    public void deleteReservation(String reservationNumber){
+        Ticket ticket = ticketRepository.findByReservationNumber(reservationNumber)
+                .orElseThrow(() -> new TicketNotFoundException(reservationNumber));
+        ticket.cancelTicket();
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/ticket/util/GuestPhone.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/util/GuestPhone.java
@@ -1,0 +1,13 @@
+package com.festimap.tiketing.domain.ticket.util;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface GuestPhone { }

--- a/src/main/java/com/festimap/tiketing/domain/ticket/util/GuestPhoneArgumentResolver.java
+++ b/src/main/java/com/festimap/tiketing/domain/ticket/util/GuestPhoneArgumentResolver.java
@@ -1,0 +1,49 @@
+package com.festimap.tiketing.domain.ticket.util;
+
+import com.festimap.tiketing.global.error.ErrorCode;
+import com.festimap.tiketing.global.error.exception.BaseException;
+import com.festimap.tiketing.global.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class GuestPhoneArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwt;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(GuestPhone.class)
+                && parameter.getParameterType().equals(String.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter param,
+                                  ModelAndViewContainer mav,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        HttpServletRequest req = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = jwt.resolveGuestToken(req);
+        if (token == null || !jwt.validateToken(token)) {
+            throw new BaseException(ErrorCode.INVALID_GUEST_TOKEN);
+        }
+
+        List<GrantedAuthority> auths = jwt.getAuthoritiesFromToken(token);
+        if (auths.stream().noneMatch(a -> a.getAuthority().equals("GUEST"))) {
+            throw new BaseException(ErrorCode.FORBIDDEN_GUEST_TOKEN);
+        }
+
+        return jwt.getAccount(token);
+    }
+}

--- a/src/main/java/com/festimap/tiketing/domain/verification/controller/VerificationController.java
+++ b/src/main/java/com/festimap/tiketing/domain/verification/controller/VerificationController.java
@@ -1,8 +1,10 @@
 package com.festimap.tiketing.domain.verification.controller;
 
+import com.festimap.tiketing.domain.verification.dto.TokenResDto;
 import com.festimap.tiketing.domain.verification.dto.VerificationCheckReqDto;
 import com.festimap.tiketing.domain.verification.dto.VerificationReqDto;
 import com.festimap.tiketing.domain.verification.service.VerificationService;
+import com.festimap.tiketing.global.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class VerificationController {
 
     private final VerificationService verificationService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/send/code")
     public void sendVerificationCode(@RequestBody @Validated VerificationReqDto verificationReqDto) {
@@ -20,7 +23,8 @@ public class VerificationController {
     }
 
     @PostMapping("/check/code")
-    public void checkVerificationCode(@RequestBody @Validated VerificationCheckReqDto verificationCheckReqDto) {
+    public TokenResDto checkVerificationCode(@RequestBody @Validated VerificationCheckReqDto verificationCheckReqDto) {
         verificationService.checkVerificationCode(verificationCheckReqDto);
+        return new TokenResDto(jwtProvider.createGuestToken(verificationCheckReqDto.getPhoneNumber()));
     }
 }

--- a/src/main/java/com/festimap/tiketing/domain/verification/dto/TokenResDto.java
+++ b/src/main/java/com/festimap/tiketing/domain/verification/dto/TokenResDto.java
@@ -1,0 +1,14 @@
+package com.festimap.tiketing.domain.verification.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenResDto {
+    private String token;
+
+    public TokenResDto(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/festimap/tiketing/global/config/WebMvcConfig.java
+++ b/src/main/java/com/festimap/tiketing/global/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.festimap.tiketing.global.config;
+
+import com.festimap.tiketing.domain.ticket.util.GuestPhoneArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final GuestPhoneArgumentResolver guestPhoneResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(guestPhoneResolver);
+    }
+}

--- a/src/main/java/com/festimap/tiketing/global/config/security/AuthorizationConfig.java
+++ b/src/main/java/com/festimap/tiketing/global/config/security/AuthorizationConfig.java
@@ -14,6 +14,7 @@ public class AuthorizationConfig {
                 .antMatchers(HttpMethod.POST, SecurityConstants.PUBLIC_POST_URLS).permitAll()
                 .antMatchers(HttpMethod.GET, SecurityConstants.PUBLIC_GET_URLS).permitAll()
                 .antMatchers(HttpMethod.GET, SecurityConstants.ACTUATOR_URL).permitAll()
+                .antMatchers(HttpMethod.DELETE, SecurityConstants.PUBLIC_DELETE_URLS).permitAll()
                 .anyRequest().authenticated();
     }
 }

--- a/src/main/java/com/festimap/tiketing/global/config/security/CorsConfig.java
+++ b/src/main/java/com/festimap/tiketing/global/config/security/CorsConfig.java
@@ -35,7 +35,7 @@ public class CorsConfig {
 
         configuration.setAllowedOrigins(ALLOWED_ORIGINS);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
-        configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization", "X-Requested-With","withcredentials"));
+        configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization", "X-Requested-With","withcredentials","X-Guest-Token"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/festimap/tiketing/global/constants/SecurityConstants.java
+++ b/src/main/java/com/festimap/tiketing/global/constants/SecurityConstants.java
@@ -17,10 +17,15 @@ public class SecurityConstants {
 
     public static final String[] PUBLIC_GET_URLS = {
             "/api/event",
-            "/api/event/isOpen"
+            "/api/event/isOpen",
+            "/api/guest/tickets"
     };
 
     public static final String[] ACTUATOR_URL = {
             "/actuator/prometheus"
+    };
+
+    public static final String[] PUBLIC_DELETE_URLS = {
+            "/api/guest/tickets/*"
     };
 }

--- a/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
+++ b/src/main/java/com/festimap/tiketing/global/error/ErrorCode.java
@@ -38,12 +38,18 @@ public enum ErrorCode {
     TICKET_SOLD_OUT("T003", "Not enough tickets remaining", 400),
     TICKET_SERVER_NOT_OPEN("T004", "Ticket Server Not Open", 400),
     TICKET_SERVICE_FINISHED("T005", "Ticket Service is Finished", 400),
+
     NOT_SUPPORTED_STRATEGY("T006","Not Supported Strategy",400),
     TICKET_SERVICE_CONGESTED("T007", "Ticketing Service Congested",500),
+    TICKET_CANCELLATION_WINDOW_EXPIRED("T007", "Ticket cancellation window expired", 400),
 
     // Event
     EVENT_ALREADY_OPEN("EVT001", "Cannot modify event after open time", 400),
     NO_REMAINING_TICKETS("EVT002", "Cannot reopen event: no remaining tickets", 400),
+
+    // Guest
+    INVALID_GUEST_TOKEN("G001", "Invalid guest token or Expired guest token", 401),
+    FORBIDDEN_GUEST_TOKEN("G003", "Token does not have GUEST role", 403),
     ;
 
     private final String code;

--- a/src/main/java/com/festimap/tiketing/global/util/JwtProvider.java
+++ b/src/main/java/com/festimap/tiketing/global/util/JwtProvider.java
@@ -58,14 +58,26 @@ public class JwtProvider {
                 .collect(Collectors.toList());
     }
 
-    public String createToken(String account, List<String> roles) {
-        Claims claims = Jwts.claims().setSubject(account);
+    public String createToken(String identifier, List<String> roles) {
+        Claims claims = Jwts.claims().setSubject(identifier);
         claims.put("roles", roles);
         Date now = new Date();
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + 3600000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createGuestToken(String phoneNumber) {
+        Claims claims = Jwts.claims().setSubject(phoneNumber);
+        claims.put("roles", List.of("GUEST"));
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + 600000))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -90,6 +102,10 @@ public class JwtProvider {
             return bearerToken.substring(7).trim();
         }
         return null;
+    }
+
+    public String resolveGuestToken(HttpServletRequest request){
+        return request.getHeader("X-Guest-Token");
     }
 
     public Authentication getAuthentication(String token) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #42 

## 📝작업 내용

1. POST /api/verification/check/code 수정 -> body에 10분간 해당 휴대전화번호가 예매한 리스트를 조회하고 취소할 수 있는 권한을 가진 토큰 전달
2. GET /api/guest/tickets 추가 -> X-Guest-Token에 1번에서 발급한 토큰을 담아서 보내주기
3. DELETE /api/guest/tickets/{reservationNumber} -> header에 X-Guest-Token에 1번에서 발급한 토큰을 담아서 보내주기


## 추가 작업 필요

1. 테스트 코드 작성 
